### PR TITLE
Update the bootstrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ mount /dev/sda3 /mnt/home
 Bootstrap the system by running this command
 
 ```
-pacstrap /mnt base base-devel
+pacstrap /mnt base linux linux-firmware
 ```
 
 It can take a few minutes to complete.


### PR DESCRIPTION
The previous bootstrap command was causing to boot into grub prompt. Changed the "pacstrap /mnt base base-devel" to "pacstrap /mnt base linux linux-firmware" to fix this issue.